### PR TITLE
Allow for [ExpectedException] without exception type

### DIFF
--- a/src/NUnitToXUnit/Extensions/AttributeSyntaxExtensions.cs
+++ b/src/NUnitToXUnit/Extensions/AttributeSyntaxExtensions.cs
@@ -14,7 +14,7 @@ namespace NUnitToXUnit.Extensions
             node.Expression.ChildNodes().First().ToString();
 
         public static AttributeArgumentSyntax GetExpectedExceptionAttributeArgument(this AttributeSyntax node) =>
-            node.ArgumentList.Arguments.First();
+            node.ArgumentList?.Arguments.FirstOrDefault();
 
         public static bool IsExceptionMessage(this AttributeArgumentSyntax node) =>
             node.Expression is LiteralExpressionSyntax;

--- a/src/NUnitToXUnit/Visitor/MethodVisitor.cs
+++ b/src/NUnitToXUnit/Visitor/MethodVisitor.cs
@@ -34,7 +34,11 @@ namespace NUnitToXUnit.Visitor
             var expectedExceptionAttribute = method.GetExpectedExceptionAttribute();
             var attributeArgument = expectedExceptionAttribute.GetExpectedExceptionAttributeArgument();
 
-            if (attributeArgument.IsExceptionMessage())
+            if (attributeArgument == null)
+            {
+                return CreateMethodFromExceptionType(attributeArgument, method, nameof(System.Exception));
+            }
+            else if (attributeArgument.IsExceptionMessage())
             {
                 return CreateMethodFromExceptionMessage(attributeArgument, method);
             }
@@ -72,9 +76,9 @@ namespace NUnitToXUnit.Visitor
             return ParseStatement($"Assert.Equal({ exceptionMessage }, exception.Message);").NormalizeWhitespace();
         }
 
-        private static MethodDeclarationSyntax CreateMethodFromExceptionType(AttributeArgumentSyntax attributeArgument, MethodDeclarationSyntax node)
+        private static MethodDeclarationSyntax CreateMethodFromExceptionType(AttributeArgumentSyntax attributeArgument, MethodDeclarationSyntax node, string overrideExceptionType = null)
         {
-            var exceptionType = attributeArgument.GetExceptionType();
+            var exceptionType = overrideExceptionType ?? attributeArgument.GetExceptionType();
             var rawStatement = CreateAssert(exceptionType, node);
             return ReplaceMethodBody(rawStatement, node);
         }


### PR DESCRIPTION
It is valid to specify the `[ExpectedException]` attribute without specifying an exception type. This allows for those instances