### PR TITLE
fix whitespace handling to not reformat document

### DIFF
--- a/src/NUnitToXUnit/Program.cs
+++ b/src/NUnitToXUnit/Program.cs
@@ -22,7 +22,7 @@ namespace NUnitToXUnit
             foreach (var file in files)
             {
                 var nUnitTree = CSharpSyntaxTree.ParseText(File.ReadAllText(file)).GetRoot();
-                var xUnitTree = new NUnitToXUnitVisitor(new DefaultOption { ConvertAssert = convertAssert }).Visit(nUnitTree).NormalizeWhitespace();
+                var xUnitTree = new NUnitToXUnitVisitor(new DefaultOption { ConvertAssert = convertAssert }).Visit(nUnitTree);
                 File.WriteAllText(file, xUnitTree.ToFullString(), Encoding.UTF8);
             }
         }

--- a/src/NUnitToXUnit/Visitor/AttributeVisitor.cs
+++ b/src/NUnitToXUnit/Visitor/AttributeVisitor.cs
@@ -14,7 +14,7 @@ namespace NUnitToXUnit.Visitor
     {
         public override SyntaxNode VisitAttribute(AttributeSyntax node)
         {
-            return base.VisitAttribute(ReplaceAttribute(node));
+            return base.VisitAttribute(ReplaceAttribute(node).NormalizeWhitespace());
         }
 
         public override SyntaxNode VisitAttributeList(AttributeListSyntax node)

--- a/src/NUnitToXUnit/Visitor/MethodVisitor.cs
+++ b/src/NUnitToXUnit/Visitor/MethodVisitor.cs
@@ -61,7 +61,7 @@ namespace NUnitToXUnit.Visitor
         {
             var exceptionMessage = expectedException.Expression.ToString();
             var rawStatement = CreateAssertFromExceptionMessage(node);
-            var statementToAdd = CreateExtraAssert(exceptionMessage);
+            var statementToAdd = CreateExtraAssert(exceptionMessage).WithTriviaFrom(node.Body.Statements.First());
             return ReplaceMethodBody(rawStatement, node).AddBodyStatements(statementToAdd);
         }
 
@@ -85,12 +85,15 @@ namespace NUnitToXUnit.Visitor
 
         private static string CreateAssert(string exceptionType, MethodDeclarationSyntax node)
         {
-            return $"Assert.Throws<{exceptionType}>(() => { node.Body });";
+            string indentedBody = node.Body.ToString().Replace("\n", "\n    ");
+
+            return $@"Assert.Throws<{exceptionType}>(() =>
+            { indentedBody });";
         }
 
         private static MethodDeclarationSyntax ReplaceMethodBody(string rawStatement, MethodDeclarationSyntax node)
         {
-            var xUnitStatement = ParseStatement(rawStatement);
+            var xUnitStatement = ParseStatement(rawStatement).WithTriviaFrom(node.Body.Statements.First());
             var methodBody = node.Body.WithStatements(new SyntaxList<StatementSyntax>().Add(xUnitStatement));
             return node.WithBody(methodBody);
         }

--- a/test/NUnitToXunit.Tests/MemberAccessTests/ThatAssertionWithStringContaining/Input.cs
+++ b/test/NUnitToXunit.Tests/MemberAccessTests/ThatAssertionWithStringContaining/Input.cs
@@ -7,7 +7,7 @@ namespace NUnitToXUnit.Testing
     {
         [Test]
         public void AssertionTest()
-        {            
+        {
             Assert.That("Hello World", Is.StringContaining("World"));
             Assert.That("Hello World", Is.StringContaining("WORLD").IgnoreCase);
 

--- a/test/NUnitToXunit.Tests/NUnitToXunit.Tests.csproj
+++ b/test/NUnitToXunit.Tests/NUnitToXunit.Tests.csproj
@@ -19,6 +19,8 @@
     <Compile Remove="MemberAccessTests\ThatAssertionsWithGenericType\Expected.cs" />
     <Compile Remove="MemberAccessTests\ThatAssertionsWithGenericType\Input.cs" />
     <Compile Remove="MemberAccessTests\ThatAssertionWithStringContaining\Expected.cs" />
+    <Compile Remove="NUnitUsingTests\KeepsOtherUsings\Expected.cs" />
+    <Compile Remove="NUnitUsingTests\KeepsOtherUsings\Input.cs" />
     <Compile Remove="TestAttributeTests\ToFact\Expected.cs" />
     <Compile Remove="TestAttributeTests\ToFact\Input.cs" />
     <Compile Remove="TestFixtureTests\ToXUnitClass\Expected.cs" />
@@ -76,6 +78,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="MemberAccessTests\ThatAssertionWithStringContaining\Expected.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="NUnitUsingTests\KeepsOtherUsings\Expected.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="NUnitUsingTests\KeepsOtherUsings\Input.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestAttributeTests\ToFact\Expected.cs">

--- a/test/NUnitToXunit.Tests/NUnitUsingTests/KeepsOtherUsings/Expected.cs
+++ b/test/NUnitToXunit.Tests/NUnitUsingTests/KeepsOtherUsings/Expected.cs
@@ -1,12 +1,19 @@
 ﻿// Copyright (c) 2018 Jetabroad Pty Limited. All Rights Reserved.
 // Licensed under the MIT license. See the LICENSE.md file in the project root for license information.
 
-using NUnit.Framework;
+using System.Linq;
+using Xunit;
 
 namespace NUnitToXUnit.Testing
 {
-    [TestFixture]
     public class Unittest
     {
+        public void SomeMethod()
+        {
+            var a = Enumerable
+                .Range(1, 100)
+                .Select(_ => "oh yeah!")
+                .ToList();
+        }
     }
 }

--- a/test/NUnitToXunit.Tests/NUnitUsingTests/KeepsOtherUsings/Input.cs
+++ b/test/NUnitToXunit.Tests/NUnitUsingTests/KeepsOtherUsings/Input.cs
@@ -2,11 +2,19 @@
 // Licensed under the MIT license. See the LICENSE.md file in the project root for license information.
 
 using NUnit.Framework;
+using System.Linq;
 
 namespace NUnitToXUnit.Testing
 {
     [TestFixture]
     public class Unittest
     {
+        public void SomeMethod()
+        {
+            var a = Enumerable
+                .Range(1, 100)
+                .Select(_ => "oh yeah!")
+                .ToList();
+        }
     }
 }

--- a/test/NUnitToXunit.Tests/NunitUsingTests.cs
+++ b/test/NUnitToXunit.Tests/NunitUsingTests.cs
@@ -8,6 +8,7 @@ namespace NUnitToXunit.Tests
     public class NunitUsingTests
     {
         [Theory]
+        [InlineData(nameof(NunitUsingTests), "KeepsOtherUsings")]
         [InlineData(nameof(NunitUsingTests), "ToXUnitUsing")]
         public void CompilationUnitVisitor_FromNUnitUsing_ToXUnitUsing(string testCategory, string testCase) =>
             SyntaxSnapshot.RunSnapshotTest(testCategory, testCase);

--- a/test/NUnitToXunit.Tests/SyntaxSnapshot.cs
+++ b/test/NUnitToXunit.Tests/SyntaxSnapshot.cs
@@ -26,9 +26,8 @@ namespace NUnitToXunit.Tests
             // system under test
             var actualTransformation = new NUnitToXUnitVisitor(new DefaultOption { ConvertAssert = true }).Visit(input);
 
-            // convert nodes to string so we can assert on them
-            var expected = expectedTransformation.NormalizeWhitespace().ToFullString();
-            var actual = actualTransformation.NormalizeWhitespace().ToFullString();
+            var expected = expectedTransformation.ToFullString();
+            var actual = actualTransformation.ToFullString();
 
             Assert.Equal(expected, actual);
         }


### PR DESCRIPTION
Program.cs (and the unit tests) called NormalizeWhitespace on the entire syntax tree, which has the affect of reformatting the entire document. It doesn't "pretty-print", it just removes all extra whitespace.

This leads to poorly formatted output. So now, we remove the global NormalizeWhitespace and replace it with smaller, targeted calls to new syntax nodes, to avoid reformatting the entire document.