### PR TITLE
Ignore message parameter for that assertions

### DIFF
--- a/src/NUnitToXUnit/Features/ConvertAsserts/ConvertThatExpression.cs
+++ b/src/NUnitToXUnit/Features/ConvertAsserts/ConvertThatExpression.cs
@@ -40,7 +40,7 @@ namespace NUnitToXUnit.Features.ConvertAsserts
 
         private static InvocationExpressionSyntax ReplaceThatAssert(InvocationExpressionSyntax node)
         {
-            if (!IsAssertWithTwoArguments(node)) return node;
+            if (!node.IsAssertThatExpression()) return node;
 
             var actual = node.ArgumentList.Arguments[0];
             var expression = node.ArgumentList.Arguments[1].Expression;
@@ -208,13 +208,6 @@ namespace NUnitToXUnit.Features.ConvertAsserts
         private static bool IsCompareOperatorAssert(InvocationExpressionSyntax node, string expressionName)
         {
             return !string.IsNullOrEmpty(expressionName) && (CompareOperatorAssertions.ContainsKey(expressionName) && node.ArgumentList.Arguments.Count == 2);
-        }
-
-        private static bool IsAssertWithTwoArguments(InvocationExpressionSyntax node)
-        {
-            // Right now we do for some subset of That assertions, this just skipping if we can not handled.
-            // And still keep the old code to let developer convert manually.
-            return node.IsAssertThatExpression() && node.ArgumentList.Arguments.Count == 2;
         }
 
         private static InvocationExpressionSyntax CreateCompareOperatorAssert(

--- a/test/NUnitToXunit.Tests/MemberAccessTests/MemberAccessTests.cs
+++ b/test/NUnitToXunit.Tests/MemberAccessTests/MemberAccessTests.cs
@@ -11,12 +11,12 @@ namespace NUnitToXunit.Tests
         [InlineData(nameof(MemberAccessTests), "XUnitAssertion")]
         [InlineData(nameof(MemberAccessTests), "HasMember")]
         [InlineData(nameof(MemberAccessTests), "ThatAssertions")]
-        [InlineData(nameof(MemberAccessTests), "ThatAssertionsWithUnhandled")]
         [InlineData(nameof(MemberAccessTests), "ThatAssertionWithStringContaining")]
         [InlineData(nameof(MemberAccessTests), "ThatAssertionsWithGenericType")]
         [InlineData(nameof(MemberAccessTests), "ThatAssertionsCollection")]
         [InlineData(nameof(MemberAccessTests), "CompareOperatorAssertion")]
         [InlineData(nameof(MemberAccessTests), "ThatAssertionsWithCompareOperator")]
+        [InlineData(nameof(MemberAccessTests), "ThatAssertionsWithMessageParameter")]
         public void MemberAccessVisitor_FromNUnitAssert_ToXUnitAssertion(string testCategory, string testCase) =>
             SyntaxSnapshot.RunSnapshotTest(testCategory, testCase);
     }

--- a/test/NUnitToXunit.Tests/MemberAccessTests/ThatAssertions/Expected.cs
+++ b/test/NUnitToXunit.Tests/MemberAccessTests/ThatAssertions/Expected.cs
@@ -35,6 +35,8 @@ namespace NUnitToXUnit.Testing
 
             Assert.Same(foo, actual);
             Assert.NotSame(bar, actual);
+
+            Assert.True(actual == expected);
         }
     }
 }

--- a/test/NUnitToXunit.Tests/MemberAccessTests/ThatAssertions/Input.cs
+++ b/test/NUnitToXunit.Tests/MemberAccessTests/ThatAssertions/Input.cs
@@ -33,6 +33,8 @@ namespace NUnitToXUnit.Testing
 
             Assert.That(actual, Is.SameAs(foo));
             Assert.That(actual, Is.Not.SameAs(bar));
+
+            Assert.That(actual == expected);
         }
     }
 }

--- a/test/NUnitToXunit.Tests/MemberAccessTests/ThatAssertionsWithMessageParameter/Expected.cs
+++ b/test/NUnitToXunit.Tests/MemberAccessTests/ThatAssertionsWithMessageParameter/Expected.cs
@@ -15,8 +15,8 @@ namespace NUnitToXUnit.Testing
 
             Assert.Null(actual);
             Assert.NotEmpty(actual);
-            Assert.That(actual, expression: Is.NotEqualTo(expected), message: "Foo");
-            Assert.That(actual, expression: Is.EqualTo(expected), message: "Bar");
+            Assert.Equal(expected, actual);
+            Assert.NotEqual(8, actual);
         }
     }
 }

--- a/test/NUnitToXunit.Tests/MemberAccessTests/ThatAssertionsWithMessageParameter/Input.cs
+++ b/test/NUnitToXunit.Tests/MemberAccessTests/ThatAssertionsWithMessageParameter/Input.cs
@@ -11,10 +11,10 @@ namespace NUnitToXUnit.Testing
             var expected = 7;
             var actual = 2 + 5;
 
-            Assert.That(actual, expression: Is.Null);
-            Assert.That(actual, expression: Is.Not.Empty);
-            Assert.That(actual, expression: Is.NotEqualTo(expected), message: "Foo");
-            Assert.That(actual, expression: Is.EqualTo(expected), message: "Bar");
+            Assert.That(actual, expression: Is.Null, $"{actual} is not null");
+            Assert.That(actual, expression: Is.Not.Empty, "this result should not null");
+            Assert.That(actual, expression: Is.EqualTo(expected), $"expected is: {expected} and actual is : {actual}");
+            Assert.That(actual, expression: Is.Not.EqualTo(8), "some error message");
         }
     }
 }

--- a/test/NUnitToXunit.Tests/NUnitToXunit.Tests.csproj
+++ b/test/NUnitToXunit.Tests/NUnitToXunit.Tests.csproj
@@ -18,6 +18,8 @@
     <Compile Remove="MemberAccessTests\ThatAssertionsWithCompareOperator\Input.cs" />
     <Compile Remove="MemberAccessTests\ThatAssertionsWithGenericType\Expected.cs" />
     <Compile Remove="MemberAccessTests\ThatAssertionsWithGenericType\Input.cs" />
+    <Compile Remove="MemberAccessTests\ThatAssertionsWithMessageParameter\Expected.cs" />
+    <Compile Remove="MemberAccessTests\ThatAssertionsWithMessageParameter\Input.cs" />
     <Compile Remove="MemberAccessTests\ThatAssertionWithStringContaining\Expected.cs" />
     <Compile Remove="NUnitUsingTests\KeepsOtherUsings\Expected.cs" />
     <Compile Remove="NUnitUsingTests\KeepsOtherUsings\Input.cs" />
@@ -42,8 +44,6 @@
     <Compile Remove="ExpectedExceptionTests\ToAssertThrowsTypeOf\Expected.cs" />
     <Compile Remove="ExpectedExceptionTests\ToAssertThrowsTypeOf\Input.cs" />
     <Compile Remove="ExpectedExceptionTests\ToAssertThrowsString\Expected.cs" />
-    <Compile Remove="MemberAccessTests\ThatAssertionsWithUnhandled\Expected.cs" />
-    <Compile Remove="MemberAccessTests\ThatAssertionsWithUnhandled\Input.cs" />
     <Compile Remove="MemberAccessTests\ThatAssertions\Expected.cs" />
     <Compile Remove="MemberAccessTests\ThatAssertions\Input.cs" />
     <Compile Remove="MemberAccessTests\ThatAssertionWithStringContaining\Input.cs" />
@@ -83,6 +83,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="MemberAccessTests\ThatAssertionsWithGenericType\Expected.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="MemberAccessTests\ThatAssertionsWithMessageParameter\Expected.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="MemberAccessTests\ThatAssertionsWithMessageParameter\Input.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="MemberAccessTests\ThatAssertionWithStringContaining\Expected.cs">
@@ -158,12 +164,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="ExpectedExceptionTests\ToAssertThrowsTypeOf\Input.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="MemberAccessTests\ThatAssertionsWithUnhandled\Expected.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="MemberAccessTests\ThatAssertionsWithUnhandled\Input.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="MemberAccessTests\ThatAssertions\Expected.cs">


### PR DESCRIPTION
I think we could ignore the custom message from previous code, I think the xUnit response message should sufficient to guide developer to fix the think that make unit test failed. 

For next I think we can find a solution to keep the message as a comment after end statement like: 

```csharp
    // before
    Assert.That(actual, expression: Is.Null, "this should be null");
    // after
    Assert.Null(actual); // this should be null
```

but there is some message are concat string with the variable like: 
```csharp
    // message by variable
    var failedMessage = "this should be null";
    Assert.That(actual, expression: Is.Null, failedMessage);
    // or custom message with interpolated string 
    Assert.That(actual, expression: Is.Null, $"{failedMessage} and actual is {actual}");
```

This is a little bit weird when we bring the message to comment after end statement like: 
```csharp
    // message by variable
    var failedMessage = "this should be null";
    Assert.Null(actual); // failedMessage 
    // or custom message with interpolated string 
    Assert.Null(actual); // {failedMessage} and actual is {actual}
```

This is the limitation when work with syntax, That's why we should ignore the message from nunit that assertions. 